### PR TITLE
Add instructions on "How to get started" to README (compatible with Heroku)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,10 +1,10 @@
 source 'https://rubygems.org'
 
+# Fix the Ruby version to avoid problems in collaboration
+ruby '2.1.2'
 
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '4.1.8'
-# Use sqlite3 as the database for Active Record
-gem 'sqlite3'
 # Use SCSS for stylesheets
 gem 'sass-rails', '~> 4.0.3'
 # Use Uglifier as compressor for JavaScript assets
@@ -12,7 +12,8 @@ gem 'uglifier', '>= 1.3.0'
 # Use CoffeeScript for .js.coffee assets and views
 gem 'coffee-rails', '~> 4.0.0'
 # See https://github.com/sstephenson/execjs#readme for more supported runtimes
-# gem 'therubyracer',  platforms: :ruby
+# Use this gem (Google V8 embedded within Ruby) instead of Node.js to avoid problems in collaboration
+gem 'therubyracer',  platforms: :ruby
 
 # Use jquery as the JavaScript library
 gem 'jquery-rails'
@@ -38,3 +39,12 @@ gem 'spring',        group: :development
 # Use debugger
 # gem 'debugger', group: [:development, :test]
 
+group :development do
+  # Use sqlite3 as the database for Active Record
+  gem 'sqlite3'
+end
+
+group :heroku do
+  gem 'pg', '0.17.1'
+  gem 'rails_12factor', '0.0.2'
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -47,11 +47,13 @@ GEM
       railties (>= 3.0, < 5.0)
       thor (>= 0.14, < 2.0)
     json (1.8.1)
+    libv8 (3.16.14.7)
     mail (2.6.3)
       mime-types (>= 1.16, < 3)
     mime-types (2.4.3)
     minitest (5.4.3)
     multi_json (1.10.1)
+    pg (0.17.1)
     rack (1.5.2)
     rack-test (0.6.2)
       rack (>= 1.0)
@@ -65,6 +67,11 @@ GEM
       bundler (>= 1.3.0, < 2.0)
       railties (= 4.1.8)
       sprockets-rails (~> 2.0)
+    rails_12factor (0.0.2)
+      rails_serve_static_assets
+      rails_stdout_logging
+    rails_serve_static_assets (0.0.2)
+    rails_stdout_logging (0.0.3)
     railties (4.1.8)
       actionpack (= 4.1.8)
       activesupport (= 4.1.8)
@@ -73,6 +80,7 @@ GEM
     rake (10.4.0)
     rdoc (4.1.2)
       json (~> 1.4)
+    ref (1.0.5)
     sass (3.2.19)
     sass-rails (4.0.4)
       railties (>= 4.0.0, < 5.0)
@@ -93,6 +101,9 @@ GEM
       activesupport (>= 3.0)
       sprockets (>= 2.8, < 4.0)
     sqlite3 (1.3.10)
+    therubyracer (0.12.1)
+      libv8 (~> 3.16.14.0)
+      ref
     thor (0.19.1)
     thread_safe (0.3.4)
     tilt (1.4.1)
@@ -111,10 +122,13 @@ DEPENDENCIES
   coffee-rails (~> 4.0.0)
   jbuilder (~> 2.0)
   jquery-rails
+  pg (= 0.17.1)
   rails (= 4.1.8)
+  rails_12factor (= 0.0.2)
   sass-rails (~> 4.0.3)
   sdoc (~> 0.4.0)
   spring
   sqlite3
+  therubyracer
   turbolinks
   uglifier (>= 1.3.0)

--- a/README.md
+++ b/README.md
@@ -4,4 +4,71 @@ thessrbio
 
 *Thessaloniki Ruby Meetup Home*
 
-This is a ruby community project
+This is a Ruby community project.
+
+Members of the [Thessaloniki Ruby Meetup (thessrb)](http://thessrb.io/) are contributing to this effort.
+
+**Join us!**
+
+
+## How to get started
+
+### Step 0. Install `Ruby version 2.1.2` & `Bundler gem`
+
+#### Install Ruby
+
+Just make sure you have installed **version 2.1.2** and this is your current version
+
+```bash
+ruby -v
+```
+
+#### Install Bundler gem
+
+```bash
+gem install bundler
+```
+
+### Step 1. Clone this repo
+
+```bash
+git clone git@github.com:thessrb/thessrbio.git
+```
+
+### Step 2. Install the dependencies
+
+Change directory to `path/to/thessrbio` and execute:
+
+```bash
+bundle install --without heroku
+```
+
+Using `--without heroku` will install only the dependencies needed during development or local testing so that you don't have to install [PostgreSQL](http://www.postgresql.org/) locally in your system.
+
+The first time you run this, it will create a `.bundle/config` file (which is git ignored) so that Bundler can "remember" your options.
+
+This way, you won't have to use this option explicitly everytime you want to update the dependencies. You only need to run:
+
+```bash
+bundle
+```
+
+Go on! Test this out, run the above command to see that it is OK.
+
+
+### Step 3. Run the tests to make sure everything is working
+
+```bash
+rake
+```
+
+### Step 4. Run the Rails server and enjoy...
+
+```bash
+bin/rails s
+```
+
+Something missing or something is wrong?
+
+**You can contribute!!!**
+


### PR DESCRIPTION
- Change 'sqlite3' to be used only in :development environment
- Add dependencies need by Heroku
- Add instructions to README on how to get started
