### PR TITLE
Remove gitter link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 thessrbio
 =========
-[![Gitter](https://badges.gitter.im/Join Chat.svg)](https://gitter.im/thessrb/thessrbio?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
 *Thessaloniki Ruby Meetup Home*
 


### PR DESCRIPTION
We are not using gitter, and I think we should make the final decision before tomorrow regarding which chat tool we are going to stick to. For now, let's remove the link if you agree @xarisd 
