### PR TITLE
Require explicit files to load css in proper order

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -10,6 +10,7 @@
  * defined in the other CSS/SCSS files in this directory. It is generally better to create a new
  * file per style scope.
  *
- *= require_tree .
+ *= require stylesheet
+ *= require custom
  *= require_self
  */


### PR DESCRIPTION
- File custom.css must be included AFTER stylesheet.css
- Always a good practice to require SPECIFIC files instead of trees or directories
