### PR TITLE
Add sensible defaults for LOCAL 'production' environment (Asset Pipeline)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@
 # Exclude public/assets which can be produce from rake tasks
 public/assets
  
+
+# Ignore application configuration
+/config/application.yml

--- a/Gemfile
+++ b/Gemfile
@@ -25,6 +25,12 @@ gem 'spring',             group: :development     # Spring speeds up development
 ############# Environment/Runtime ##################################
 gem 'therubyracer',       platforms: :ruby        # Use this gem (Google V8 embedded within Ruby) instead of Node.js to avoid problems in collaboration. See https://github.com/sstephenson/execjs#readme for more supported runtimes
 
+############# Configuration #######################################
+gem 'figaro', '~> 1.0.0'                          # For reading environment viraibles from config/application.yml. See https://github.com/laserlemon/figaro
+gem 'wannabe_bool', '~> 0.1.0'                    # For converting string, integer, symbol and nil values to a boolean value with #to_b method, helper for using the figaro gem values
+
+
+
 
 ############# DEVELOPMENT ONLY ####################################
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -38,6 +38,8 @@ GEM
     coffee-script-source (1.8.0)
     erubis (2.7.0)
     execjs (2.2.2)
+    figaro (1.0.0)
+      thor (~> 0.14)
     hike (1.2.3)
     i18n (0.6.11)
     jbuilder (2.2.5)
@@ -114,12 +116,14 @@ GEM
     uglifier (2.5.3)
       execjs (>= 0.3.0)
       json (>= 1.8.0)
+    wannabe_bool (0.1.0)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
   coffee-rails (~> 4.0.0)
+  figaro (~> 1.0.0)
   jbuilder (~> 2.0)
   jquery-rails
   pg
@@ -132,3 +136,4 @@ DEPENDENCIES
   therubyracer
   turbolinks
   uglifier (>= 1.3.0)
+  wannabe_bool (~> 0.1.0)

--- a/config/application.example.yml
+++ b/config/application.example.yml
@@ -1,0 +1,3 @@
+# Add configuration values here, as shown below.
+SECRET_KEY_BASE: "Please change the key here by generating a secret with 'rake secret' in your console and then pasting the value here"
+SERVE_ASSETS_IN_PRODUCTION_FROM_RAILS: "true"

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -19,8 +19,8 @@ Rails.application.configure do
   # For large-scale production use, consider using a caching reverse proxy like nginx, varnish or squid.
   # config.action_dispatch.rack_cache = true
 
-  # Disable Rails's static asset server (Apache or nginx will already do this).
-  config.serve_static_assets = false
+  # Disable Rails's static asset server IF Apache or nginx will already do this.
+  config.serve_static_assets = ENV["SERVE_ASSETS_IN_PRODUCTION_FROM_RAILS"].to_b || false
 
   # Compress JavaScripts and CSS.
   config.assets.js_compressor = :uglifier

--- a/lib/tasks/dev.rake
+++ b/lib/tasks/dev.rake
@@ -1,0 +1,29 @@
+namespace :dev do
+  namespace :prepare do
+    desc "(Mac/Linux only): Prepares the production env for LOCAL development by creating config/application.yml'"
+    task :production_local do
+      `rm config/application.yml`
+      `touch config/application.yml`
+      key = `rake secret`
+      `echo 'SECRET_KEY_BASE: #{key}' >> config/application.yml`
+      `echo 'SERVE_ASSETS_IN_PRODUCTION_FROM_RAILS: "true"' >> config/application.yml`
+      puts %Q{
+
+Done! (config/application.yml file created)
+
+ATTENTION : If you  have Apache on nginx to serve the static assets
+
+Please set the key
+  SERVE_ASSETS_IN_PRODUCTION_FROM_RAILS: "true"
+in
+  'config/application.yml'
+
+Oh! And if that's the case, do not forget to precompile the assets :-)
+
+    rake assets:precompile
+
+
+}
+    end
+  end
+end


### PR DESCRIPTION
- Use gems 'figaro' and 'wannabe_bool' for setting ENV variables from a file (config/application.yml)
- Change 'config/environments/production.rb' to include an environment variable that switches on/off if assets will be served from Rails or not.
- Create a sample file 'config/application.example.yml' for easy reference
- Create a simple rake task 'rake dev:prepare:production_local' for automatically generate an application.yml file
