### PR TITLE
Fix for forkme_banner blacktocat image

### DIFF
--- a/app/assets/stylesheets/custom.css
+++ b/app/assets/stylesheets/custom.css
@@ -31,9 +31,7 @@
   top:0;
   right: 10px;
   z-index: 10;
-  padding: 10px 10px 10px 10px;
   color: #fff;
-  background: #0090ff;
   font-weight: 700;
   box-shadow: 0 0 10px rgba(0,0,0,.5);
   border-bottom-left-radius: 2px;

--- a/app/assets/stylesheets/stylesheet.css.erb
+++ b/app/assets/stylesheets/stylesheet.css.erb
@@ -279,7 +279,7 @@ Full-Width Styles
   z-index: 10;
   padding: 10px 50px 10px 10px;
   color: #fff;
-  background: url('../images/blacktocat.png') #0090ff no-repeat 95% 50%;
+  background: url(<%= asset_path 'blacktocat.png' %>) #0090ff no-repeat 95% 50%;
   font-weight: 700;
   box-shadow: 0 0 10px rgba(0,0,0,.5);
   border-bottom-left-radius: 2px;


### PR DESCRIPTION
Related to issue #45

Edit after the greatly appreciated suggestions of @petros and @xaris:
1. Renamed stylesheet.css to stylesheet.css.erb (because of point (2))
2. Changed the url of the background for forkme_banner to access the image asset. (previously the url led to ../images/blacktocat.png which, of course, is not accessible)
3. Deleted padding and background rules from custom.css in order to show the blacktocat.png image.

The expected result is pretty much the same as in [thessrb.io](http://thessrb.io/), as far as the forkme_banner is concerned.
