### PR TITLE
Presentations page without database

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@ public/assets
 
 # Ignore application configuration
 /config/application.yml
+
+# Ignore .swp files
+*.swp

--- a/app/assets/stylesheets/custom.css
+++ b/app/assets/stylesheets/custom.css
@@ -55,3 +55,14 @@ ul.members-list li span.name {
   font-weight: bold;
 }
 
+.sort_header {
+  font-family: 'Lucida Grande', 'Helvetica Neue', Helvetica, Arial, sans-serif;
+  padding: 10px;
+  background: #373737;
+  color: #fff;
+}
+
+.sort_header:hover, .sort_header:focus {
+  text-decoration: underline;
+}
+

--- a/app/controllers/presentations_controller.rb
+++ b/app/controllers/presentations_controller.rb
@@ -6,7 +6,7 @@ class PresentationsController < ApplicationController
 			@presentations = @presentations.sort {|ppt1, ppt2| ppt1.title <=> ppt2.title}
 		elsif params[:sort_by] == 'date'
 			@presentations = @presentations.sort {|ppt1, ppt2| ppt1.date_presented <=> ppt2.date_presented}
-		elsif params[:sort_by] == 'presentor'
+		elsif params[:sort_by] == 'presenter'
 			@presentations = @presentations.sort {|ppt1, ppt2| ppt1.presenter <=> ppt2.presenter}
 		end
 	end

--- a/app/controllers/presentations_controller.rb
+++ b/app/controllers/presentations_controller.rb
@@ -1,0 +1,13 @@
+class PresentationsController < ApplicationController
+
+	def index
+		@presentations = Presentation.all
+		if params[:sort_by] == 'title'
+			@presentations = @presentations.sort {|ppt1, ppt2| ppt1.title <=> ppt2.title}
+		elsif params[:sort_by] == 'date'
+			@presentations = @presentations.sort {|ppt1, ppt2| ppt1.date_presented <=> ppt2.date_presented}
+		elsif params[:sort_by] == 'presentor'
+			@presentations = @presentations.sort {|ppt1, ppt2| ppt1.presenter <=> ppt2.presenter}
+		end
+	end
+end

--- a/app/models/presentation.rb
+++ b/app/models/presentation.rb
@@ -1,0 +1,30 @@
+class Presentation
+	attr_accessor :title, :url, :date_presented, :presenter
+
+    def initialize(attributes)
+        @title = attributes[:title]
+        @url = attributes[:url]
+        @date_presented = Date.strptime(attributes[:date_presented], "%d/%m/%Y")
+        @presenter = attributes[:presenter]
+    end
+
+    def self.all
+        presentations = [{:title => 'git and GitHub', :url => 'https://github.com/thessrb/meetup/blob/master/meetups/2/presentations/gitAndGithub/AppCampGr2011Preso.pdf?raw=true', :date_presented => '06/09/2011', :presenter => 'Petros Amiridis'},
+    {:title => 'Simple Web Apps with Sinatra', :url => 'http://prezi.com/de5yqj9sa9zq/simple-webapps-with-sinatra/', :date_presented => '06/09/2011', :presenter => 'Vassilis Rizopoulos'},
+    {:title => "Ruby Gems are Pragmatic Programmer's Best Friends", :url => 'https://github.com/thessrb/meetup/blob/master/meetups/3/Ruby%2Bgems%2Bare%2Bpragmatic%2Bprogrammer%2527s%2Bbest%2Bfriends.pdf', :date_presented => '01/11/2011', :presenter => 'Konstantinos Kostopoulos'},
+    {:title => 'Codigia - a dispersed team example', :url => 'https://github.com/thessrb/meetup/blob/master/meetups/4/presentations/Codigia-DispersedTeamExample/meetup_4_slides.pdf', :date_presented => '29/11/2011', :presenter => 'Stefanos Togoulidis'},
+    {:title => 'Introduction to configuration management with Puppet', :url => 'https://speakerdeck.com/robbyt/introduction-to-puppet', :date_presented => '24/09/2013', :presenter => 'Robert Terhaar'},
+    {:title => 'Introduction to Functional Programming with Elixir', :url => 'https://docs.google.com/presentation/d/1Bku0-9Eu9k_lTMnAQOYpsbiRGlSaMXxo_7MPEl7bm0s/edit?pli=1#slide=id.p', :date_presented => '29/10/2013', :presenter => 'Vassilis Rizopoulos'},
+    {:title => 'Decreasing technical debt with SonarQube', :url => 'http://www.slideshare.net/ppapapetrou/thessaloniki-rb24', :date_presented => '28/01/2014', :presenter => 'Patroklos Papapetrou'},
+    {:title => 'Lambda calculus for programmers', :url => 'https://drive.google.com/file/d/0B2yeyDGqvZRQTnpxRmRjYTVQRnM/edit?usp=sharing', :date_presented => '18/02/2014', :presenter => 'Kostas Lolas'},
+    {:title => 'Agile Methodologies — Manage and code without losing your head', :url => 'https://speakerdeck.com/krap/agile-methodologies-manage-and-code-without-losing-your-head', :date_presented => '18/03/2014', :presenter => 'Apostolos Kritikos'},
+    {:title => 'Ruby Basics', :url => 'http://xarisd.io/presentations/ruby-basics-ii/#/', :date_presented => '19/06/2014', :presenter => 'Haris Dimitriou'},
+    {:title => 'Introduction to Ruby on Rails', :url => 'https://speakerdeck.com/petros/thessaloniki-ruby-meetup-and-rubyzino-number-30', :date_presented => '30/09/2014', :presenter => 'Petros Amiridis'},
+    {:title => 'Create the first pages of our Rails app and deploy to Heroku', :url => 'http://xarisd.io/presentations/rails-basics-01/#/', :date_presented => '25/10/2014', :presenter => 'Haris Dimitriou'},
+    ]
+    
+        presentations.map do |presentation|
+            Presentation.new presentation
+        end
+    end
+end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -16,13 +16,20 @@
       <h2 id="project_tagline">Official Thessaloniki Ruby Meetup Home</h2>
 
       <section id="menu">
-        <% if @current_page == 'home' %>
-          <span class="current">Home</span>
-          <a class="" href="members">Members</a>
-        <% elsif @current_page == 'members' %>
-          <a class="" href="/">Home</a>
-          <span class="current">Members</span>
-        <% end %>
+        <% case @current_page
+            when 'home' %>
+            <span class="current">Home</span>
+            <a class="" href="members">Members</a>
+            <a class="" href="presentations">Knowledge Base</a>
+          <% when 'members' %>
+            <a class="" href="/">Home</a>
+            <span class="current">Members</span>
+            <a class="" href="presentations">Knowledge Base</a>
+          <% when 'presentations' %>
+            <a class="" href="/">Home</a>
+            <a class=""  href="members">Members</a>
+            <span class="current" href="presentations">Presentations</span>
+          <% end %>
       </section>
     </header>
   </div>

--- a/app/views/presentations/index.html.erb
+++ b/app/views/presentations/index.html.erb
@@ -1,0 +1,29 @@
+<%
+
+@current_page = "presentations"
+@title = ""
+
+%>
+
+<div id="main_content_wrap" class="outer">
+  <section id="main_content" class="inner">
+  <p>We like open-source. We also like Ruby and Rails framework. We love fiddling around with technology.</p>
+  <p>This is the very reason we want our presentations base to be open for everyone</p>
+  <p>Below, you can find our presentations, up until now</p>
+  
+  <table>
+	  <tr>
+	  	<th><%= link_to 'Title', {:controller => 'presentations', :action => 'index', :sort_by => 'title'}, :class => 'sort_header'%></th>
+	  	<th><%= link_to 'Date', {:controller => 'presentations', :action => 'index', :sort_by => 'date'}, :class => 'sort_header'%></th>
+	  	<th><%= link_to 'Details', {:controller => 'presentations', :action => 'index', :sort_by => 'presentor'}, :class => 'sort_header'%></th>
+	  </tr>
+	  	<% @presentations.each do |presentation|%>
+	  	<tr>
+	  		<td><%= link_to presentation.title, presentation.url %></td>
+	  		<td><%= presentation.date_presented.strftime("%d/%m/%Y") %></td>
+	  		<td>Presented by <%= presentation.presenter %>.</td>
+	  	</tr>
+	  	<% end %>
+  </table>
+  </section>
+</div>

--- a/app/views/presentations/index.html.erb
+++ b/app/views/presentations/index.html.erb
@@ -15,7 +15,7 @@
 	  <tr>
 	  	<th><%= link_to 'Title', {:controller => 'presentations', :action => 'index', :sort_by => 'title'}, :class => 'sort_header'%></th>
 	  	<th><%= link_to 'Date', {:controller => 'presentations', :action => 'index', :sort_by => 'date'}, :class => 'sort_header'%></th>
-	  	<th><%= link_to 'Details', {:controller => 'presentations', :action => 'index', :sort_by => 'presentor'}, :class => 'sort_header'%></th>
+	  	<th><%= link_to 'Details', {:controller => 'presentations', :action => 'index', :sort_by => 'presenter'}, :class => 'sort_header'%></th>
 	  </tr>
 	  	<% @presentations.each do |presentation|%>
 	  	<tr>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,7 @@
 Rails.application.routes.draw do
   root 'home#index'
   get 'members', :to => 'members#index'
+  get 'presentations', :to => 'presentations#index'
 
 
 


### PR DESCRIPTION
Created a 3rd page in the webpage where the presentations available from past meetups are presented to the user.

More specifically:
* Added the page, creating a new view (*app/views/presentations/index.html.erb*)
* Changed the layout view to provide access to the new view
* Minor addition in *custom.css*
* Created a controller for the new view (*app/controllers/presentations_controller.rb*)
    * support for sorting
* Added the relevant route
* Created model Presentation class (*app/models/presentation.rb*)

Concerning pull request #50, the changes that were discussed were applied.

Screenshot preview:

![knowledge-base-page](https://cloud.githubusercontent.com/assets/5221013/5606746/5b9cb960-9446-11e4-8d50-899ebc6913ee.png)